### PR TITLE
feat(CSN-780): new endpoint to receive hotkey reliability report

### DIFF
--- a/compute/utils/db.py
+++ b/compute/utils/db.py
@@ -69,6 +69,22 @@ class ComputeDb:
                 """
             )
 
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS hotkey_reliability_report (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp TIMESTAMP,
+                    hotkey TEXT,
+                    rentals INTEGER,
+                    failed INTEGER,
+                    rentals_14d INTEGER,
+                    failed_14d INTEGER,
+                    aborted INTEGER,
+                    rental_best INTEGER,
+                    blackllisted BOOLEAN
+                )
+            """
+            )
             self.conn.commit()
         except Exception as e:
             self.conn.rollback()


### PR DESCRIPTION

Add a new table to store the following information
```
timestamp
hotkey
rentals: life count 
failed:  life count external deallocation
rentals_14d: 2 week count
failed_14d: 2 week external deallocation
aborted: life count of failed allocations
rental_best: (longest rental)
blackllisted: blacklisted from the dashboard
```

also save this to wandb