### PR TITLE
fix(CSN-876): resolve miners stats discrepancy between valis

### DIFF
--- a/compute/__init__.py
+++ b/compute/__init__.py
@@ -18,9 +18,9 @@
 import string
 
 # Define the version of the template module.
-__version__ = "1.8.7"
+__version__ = "1.8.8"
 __minimal_miner_version__ = "1.8.5"
-__minimal_validator_version__ = "1.8.7"
+__minimal_validator_version__ = "1.8.8"
 
 version_split = __version__.split(".")
 __version_as_int__ = (100 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/compute/wandb/wandb.py
+++ b/compute/wandb/wandb.py
@@ -375,8 +375,14 @@ class ComputeWandb:
                     for uid, data in stats_data.items():
                         # If you also want allocated == True, re-enable that check:
                         # if data.get("own_score") is True and data.get("allocated") is True:
-                        if data.get("own_score") is True:
+                        if data.get("own_score") is True and data.get("score", 0) > 0 and data.get("allocated") is True:
                             aggregator.setdefault(uid, []).append(data)
+                            # Pull out gpu_specs for logging
+                            gs = data.get("gpu_specs") or {}
+                            bt.logging.trace(
+                                f"Added stats for UID {uid} from validator hotkey {run.config['hotkey']} | "
+                                f"GPU specs: {gs.get('gpu_name', 'N/A')} x {gs.get('num_gpus', 0)}"
+                            )
 
             except Exception as e:
                 bt.logging.info(f"Run ID: {run.id}, Name: {run.name}, Error: {e}")

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -95,7 +95,7 @@ class Miner:
     _axon: bt.axon
 
     @property
-    def wallet(self) -> bt.wallet:
+    def wallet(self) -> bt.wallet: # type: ignore
         return self._wallet
 
     @property

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -328,6 +328,26 @@ class Validator:
         # Calculate score
         for uid in self.uids:
             try:
+                if uid not in self._queryable_uids:
+                    hotkey = self.metagraph.axons[uid].hotkey
+                    self.stats[uid] = {
+                        "hotkey": hotkey,
+                        "allocated": hotkey in self.allocated_hotkeys,
+                        "own_score": True,
+                        "score": 0,
+                        "gpu_specs": None,
+                        "reliability_score": 0.0
+                        }
+                    self.scores[uid] = 0
+
+                    # Remove entry from PoG stats
+                    cursor = self.db.get_cursor()
+                    cursor.execute(
+                        "DELETE FROM pog_stats WHERE hotkey = ?",
+                        (hotkey,),
+                    )
+                    continue  # Skip further processing for this uid
+
                 axon = self._queryable_uids[uid]
                 hotkey = axon.hotkey
 
@@ -349,20 +369,27 @@ class Validator:
                 else:
                     # If not found locally, try fallback from stats_allocated
                     if uid in self.stats_allocated:
-                        score = self.stats_allocated[uid].get("score", 0)/100
-                        gpu_specs = self.stats_allocated[uid].get("gpu_specs", None)
-                        self.stats[uid]["own_score"] = False  # or "no"
+                        if isinstance(self.stats_allocated[uid].get("gpu_specs", None), dict):
+                            gpu_specs = self.stats_allocated[uid].get("gpu_specs", None)
+                            score = self.stats_allocated[uid].get("score", 0)
+                            self.stats[uid]["own_score"] = False
+                        else:
+                            gpu_specs = None
+                            score = 0
+                            self.stats[uid]["own_score"] = True
                     else:
                         score = 0
-                        self.stats[uid]["own_score"] = True  # or "no"
+                        gpu_specs = None
+                        self.stats[uid]["own_score"] = True
                 
                 if hotkey in self.penalized_hotkeys:
                     score = 0
                 self.stats[uid]["score"] = score*100
                 self.stats[uid]["gpu_specs"] = gpu_specs
+
                 # Keep or override reliability_score if you want
                 if "reliability_score" not in self.stats[uid]:
-                    self.stats[uid]["reliability_score"] = 0
+                    self.stats[uid]["reliability_score"] = 0.0
 
             except KeyError as e:
                 bt.logging.trace(f"KeyError occurred for UID {uid}: {str(e)}")


### PR DESCRIPTION
Refactored the stats attribution logic in the validation mechanism to ensure reliability and accuracy of GPU stats and scores. The update includes:

- Eliminated the use of shared GPU stats when the reported score is zero or the miner is not currently allocated.
- Ensuring each validator performs its own PoG challenge unless verified conditions are met.
- Preventing untracked or stale entries by safely handling UIDs that are not queryable.